### PR TITLE
[WIP] prepare for push subscription

### DIFF
--- a/aggregation/README.md
+++ b/aggregation/README.md
@@ -55,7 +55,7 @@ Set the version:
 export AGGREGATION_VERSION=`git rev-parse HEAD`
 ```
 
-Build the docker image on GCP and deploy as Cloud Run:
+Build the docker image on GCP:
 ```bash
 gcloud builds submit --tag eu.gcr.io/$GCP_PROJECT/aggregation_application:$AGGREGATION_VERSION --project $GCP_PROJECT
 ```
@@ -78,6 +78,6 @@ gcloud scheduler jobs create http aggregation-schedule \
   --schedule="*/10 * * * *" \
   --uri="$AGGREGATION_APPLICATION_BASE_URL/aggregate-from-providers" \
   --http-method POST \
-  --oidc-service-account-email=642254565385-compute@developer.gserviceaccount.com \
+  --oidc-service-account-email=$GCP_PROJECT_NUMBER-compute@developer.gserviceaccount.com \
   --oidc-token-audience="$AGGREGATION_APPLICATION_BASE_URL"
 ```

--- a/aggregation/src/Application/Application.fsproj
+++ b/aggregation/src/Application/Application.fsproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="FsToolkit.ErrorHandling" Version="4.9.0" />
     <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="4.9.0" />
-    <PackageReference Include="Giraffe" Version="5.0.0-rc-6" />
-    <PackageReference Include="Giraffe.ViewEngine" Version="1.3.*" />
+    <PackageReference Include="Giraffe" Version="6.2.0" />
+    <PackageReference Include="Giraffe.ViewEngine" Version="1.4.0" />
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.6.0" />
     <PackageReference Include="Ply" Version="0.3.*" />
   </ItemGroup>

--- a/forwarding/.gitignore
+++ b/forwarding/.gitignore
@@ -1,1 +1,2 @@
 .idea
+artifacts

--- a/forwarding/README.md
+++ b/forwarding/README.md
@@ -9,3 +9,88 @@ The bounded context contains two deployables:
 
 - `Application.PubSubForwarding`: Forward signals to customers via Pub/Sub.
 - `Application.WebhookForwarding`: Forward signals to customers via Webhooks.
+
+## Local Development
+
+### Build
+
+```bash
+dotnet build
+```
+
+### Test
+
+```bash
+# TODO: tests
+dotnet test
+```
+
+### Run
+Each deployable can be run by changing to its directory in `src/`
+and running
+```bash
+dotnet run
+```
+
+### Sending a signal
+
+Both deployables expect Pub/Sub messages containing signals as data
+delivered via POST to the root route:
+```bash
+export SIGNAL_JSON="
+{
+  \"Latitude\": 1.0,
+  \"Longitude\": 2.0,
+  \"Timestamp\": \"2023-09-01T07:17:11Z\",
+  \"ValidationResult\": {
+    \"Case\": \"Valid\"
+  }
+}"
+
+curl -k -H "Content-Type: application/json" -d \
+"{
+  \"message\": {
+    \"data\": \"$(echo $SIGNAL_JSON | base64 -w 0)\"
+  }
+}" \
+https://localhost:5001/
+```
+
+## Deployment
+
+### Deploying a new app version
+
+Build the release version:
+```bash
+dotnet build Aggregation.sln -c Release
+```
+
+Publish it and change directory:
+```bash
+dotnet publish src/Application/Application.fsproj --no-build -c Release -o artifacts/aggregation-application
+cd artifacts/aggregation-application
+``
+
+Set the GCP project to deploy to:
+```bash
+export GCP_PROJECT=ddd-vienna-sample
+```
+
+Set the version:
+```bash
+export AGGREGATION_VERSION=`git rev-parse HEAD`
+```
+
+Build the docker image on GCP and deploy as Cloud Run:
+```bash
+gcloud builds submit --tag eu.gcr.io/$GCP_PROJECT/aggregation_application:$AGGREGATION_VERSION --project $GCP_PROJECT
+```
+
+Deploy as Cloud Run:
+```bash
+gcloud run deploy aggregation-application --image eu.gcr.io/$GCP_PROJECT/aggregation_application:$AGGREGATION_VERSION --region europe-west1
+```
+
+### One-Time Setup
+
+# TODO: create a push subscription

--- a/forwarding/src/Application.PubSubForwarding/Application.PubSubForwarding.fsproj
+++ b/forwarding/src/Application.PubSubForwarding/Application.PubSubForwarding.fsproj
@@ -13,6 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Dockerfile">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Compile Include="Routes.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/forwarding/src/Application.PubSubForwarding/Application.PubSubForwarding.fsproj
+++ b/forwarding/src/Application.PubSubForwarding/Application.PubSubForwarding.fsproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="Routes.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/forwarding/src/Application.PubSubForwarding/Application.PubSubForwarding.fsproj
+++ b/forwarding/src/Application.PubSubForwarding/Application.PubSubForwarding.fsproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Giraffe" Version="5.0.0-rc-6" />
-    <PackageReference Include="Giraffe.ViewEngine" Version="1.3.*" />
+    <PackageReference Include="Giraffe" Version="6.2.0" />
+    <PackageReference Include="Giraffe.ViewEngine" Version="1.4.0" />
     <PackageReference Include="Ply" Version="0.3.*" />
   </ItemGroup>
 

--- a/forwarding/src/Application.PubSubForwarding/Dockerfile
+++ b/forwarding/src/Application.PubSubForwarding/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+COPY . /app
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+ENTRYPOINT ["dotnet", "Forwarding.Application.PubSubForwarding.dll"]

--- a/forwarding/src/Application.PubSubForwarding/Program.fs
+++ b/forwarding/src/Application.PubSubForwarding/Program.fs
@@ -10,14 +10,6 @@ open Microsoft.Extensions.Logging
 open Microsoft.Extensions.DependencyInjection
 open Giraffe
 
-let webApp =
-    choose [
-        GET >=>
-            choose [
-                route "/" >=> text "Forwarding.Application.PubSubForwarding"
-            ]
-        setStatusCode 404 >=> text "Not Found" ]
-
 // ---------------------------------
 // Error handler
 // ---------------------------------
@@ -49,7 +41,7 @@ let configureApp (app : IApplicationBuilder) =
             .UseHttpsRedirection())
         .UseCors(configureCors)
         .UseStaticFiles()
-        .UseGiraffe(webApp)
+        .UseGiraffe(Routes.routes)
 
 let configureServices (services : IServiceCollection) =
     services.AddCors()    |> ignore

--- a/forwarding/src/Application.PubSubForwarding/Routes.fs
+++ b/forwarding/src/Application.PubSubForwarding/Routes.fs
@@ -6,7 +6,7 @@ open FsToolkit.ErrorHandling
 
 let signalHandler =
     let handler = fun signal -> taskResult {
-        System.Console.Out.WriteLine("Forwarding signal via Pub/Sub")
+        System.Console.Out.WriteLine($"Forwarding signal via Pub/Sub: {signal}")
     } 
     Common.SignalSubscription.httpHandler handler
 

--- a/forwarding/src/Application.PubSubForwarding/Routes.fs
+++ b/forwarding/src/Application.PubSubForwarding/Routes.fs
@@ -1,0 +1,23 @@
+module Application.PubSubForwarding.Routes
+
+open Giraffe
+open Microsoft.AspNetCore.Http
+open FsToolkit.ErrorHandling
+
+let signalHandler =
+    let handler = fun signal -> taskResult {
+        System.Console.Out.WriteLine("Forwarding signal via Pub/Sub")
+    } 
+    Common.SignalSubscription.httpHandler handler
+
+let routes : HttpFunc -> HttpContext -> HttpFuncResult =
+    choose [
+        GET >=>
+            choose [
+                route "/" >=> text "Forwarding BC (Pub/Sub)"
+            ]
+        POST >=>
+            choose [
+                route "/" >=> signalHandler
+            ]
+        setStatusCode 404 >=> text "Not Found" ]    

--- a/forwarding/src/Application.WebhookForwarding/Application.WebhookForwarding.fsproj
+++ b/forwarding/src/Application.WebhookForwarding/Application.WebhookForwarding.fsproj
@@ -13,6 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Dockerfile">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Compile Include="Routes.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/forwarding/src/Application.WebhookForwarding/Application.WebhookForwarding.fsproj
+++ b/forwarding/src/Application.WebhookForwarding/Application.WebhookForwarding.fsproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="Routes.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/forwarding/src/Application.WebhookForwarding/Application.WebhookForwarding.fsproj
+++ b/forwarding/src/Application.WebhookForwarding/Application.WebhookForwarding.fsproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Giraffe" Version="5.0.0-rc-6" />
-    <PackageReference Include="Giraffe.ViewEngine" Version="1.3.*" />
+    <PackageReference Include="Giraffe" Version="6.2.0" />
+    <PackageReference Include="Giraffe.ViewEngine" Version="1.4.0" />
     <PackageReference Include="Ply" Version="0.3.*" />
   </ItemGroup>
 

--- a/forwarding/src/Application.WebhookForwarding/Dockerfile
+++ b/forwarding/src/Application.WebhookForwarding/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+COPY . /app
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+ENTRYPOINT ["dotnet", "Forwarding.Application.WebhookForwarding.dll"]

--- a/forwarding/src/Application.WebhookForwarding/Program.fs
+++ b/forwarding/src/Application.WebhookForwarding/Program.fs
@@ -10,14 +10,6 @@ open Microsoft.Extensions.Logging
 open Microsoft.Extensions.DependencyInjection
 open Giraffe
 
-let webApp =
-    choose [
-        GET >=>
-            choose [
-                route "/" >=> text "Forwarding.Application.WebhookForwarding"
-            ]
-        setStatusCode 404 >=> text "Not Found" ]
-
 // ---------------------------------
 // Error handler
 // ---------------------------------
@@ -49,7 +41,7 @@ let configureApp (app : IApplicationBuilder) =
             .UseHttpsRedirection())
         .UseCors(configureCors)
         .UseStaticFiles()
-        .UseGiraffe(webApp)
+        .UseGiraffe(Routes.routes)
 
 let configureServices (services : IServiceCollection) =
     services.AddCors()    |> ignore

--- a/forwarding/src/Application.WebhookForwarding/Routes.fs
+++ b/forwarding/src/Application.WebhookForwarding/Routes.fs
@@ -6,7 +6,7 @@ open FsToolkit.ErrorHandling
 
 let signalHandler =
     let handler = fun signal -> taskResult {
-        System.Console.Out.WriteLine("Forwarding signal via Webhook")
+        System.Console.Out.WriteLine($"Forwarding signal via Webhook: {signal}")
     } 
     Common.SignalSubscription.httpHandler handler
 

--- a/forwarding/src/Application.WebhookForwarding/Routes.fs
+++ b/forwarding/src/Application.WebhookForwarding/Routes.fs
@@ -1,0 +1,23 @@
+module Application.WebhookForwarding.Routes
+
+open Giraffe
+open Microsoft.AspNetCore.Http
+open FsToolkit.ErrorHandling
+
+let signalHandler =
+    let handler = fun signal -> taskResult {
+        System.Console.Out.WriteLine("Forwarding signal via Webhook")
+    } 
+    Common.SignalSubscription.httpHandler handler
+
+let routes : HttpFunc -> HttpContext -> HttpFuncResult =
+    choose [
+        GET >=>
+            choose [
+                route "/" >=> text "Forwarding BC (Webhook)"
+            ]
+        POST >=>
+            choose [
+                route "/" >=> signalHandler
+            ]
+        setStatusCode 404 >=> text "Not Found" ]

--- a/forwarding/src/Common/Common.fsproj
+++ b/forwarding/src/Common/Common.fsproj
@@ -9,4 +9,13 @@
     <Compile Include="SignalSubscription.fs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\aggregation\src\Contracts\Contracts.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="4.9.0" />
+    <PackageReference Include="Giraffe" Version="6.2.0" />
+  </ItemGroup>
+
 </Project>

--- a/forwarding/src/Common/SignalSubscription.fs
+++ b/forwarding/src/Common/SignalSubscription.fs
@@ -1,5 +1,34 @@
-﻿namespace Common
+﻿module Common.SignalSubscription
 
-module Say =
-    let hello name =
-        printfn "Hello %s" name
+open System.Text.Json
+open System.Threading.Tasks
+open Aggregation.Contracts
+open Aggregation.Contracts.Signals.V1
+open FsToolkit.ErrorHandling
+open Giraffe
+open Microsoft.AspNetCore.Http
+
+type PubSubMessage = {
+    Data: string
+}
+
+type PubSubEvent = {
+    Message: PubSubMessage
+}
+
+let httpHandler (handler: Signal -> TaskResult<unit, exn>) = fun next (ctx: HttpContext) -> task {
+    let! body = ctx.ReadBodyFromRequestAsync()
+    let event = JsonSerializer.Deserialize<PubSubEvent>(body)
+    
+    let signal =
+        event.Message.Data
+        |> System.Convert.FromBase64String
+        |> System.Text.Encoding.UTF8.GetString
+        |> Signals.V1.deserialize
+    
+    let! result = signal |> handler
+    
+    match result with
+    | Ok _ -> return! json {|  |} next ctx
+    | Error e -> return! ServerErrors.INTERNAL_ERROR e.Message next ctx
+}


### PR DESCRIPTION
This PR prepares the code so that `forwarding` can be deployed as 2 cloud run instances each having a Pub/Sub HTTP Push Subscription to the `aggregation-signals-topic`.

TODO:
- [x] Instructions for local build, test, running, send a signal in README.md
- [x] Deploy via commandline & add to README.md
- [x] One-time-setup: Pub/Sub subscription via commandline