### PR TITLE
aggregation infra deps via docker compose

### DIFF
--- a/aggregation/README.md
+++ b/aggregation/README.md
@@ -6,6 +6,15 @@ these signals to other BCs in the signals domain.
 
 ## Local Development
 
+### Infrastructure Dependencies
+
+This bounded context has infrastructure dependencies (e.g. PostgreSQL).
+To make them available when running locally, start them via Docker using
+
+```bash
+./run-infra-deps.sh
+```
+
 ### Build
 
 ```bash

--- a/aggregation/docker-compose.infra.yml
+++ b/aggregation/docker-compose.infra.yml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  aggregation-postgres:
+    image: postgres:15
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres-data:/data
+  aggregation-postgres-admin:
+    image: dpage/pgadmin4:7.6
+    depends_on:
+      - aggregation-postgres
+    ports:
+      - "8081:80"
+    environment:
+      PGADMIN_DEFAULT_EMAIL: postgres@ddd-vienna.com
+      PGADMIN_DEFAULT_PASSWORD: postgres
+      PGADMIN_LISTEN_PORT: 80
+    volumes:
+      - ./infra/postgres/servers.json:/pgadmin4/servers.json
+volumes:
+  postgres-data:
+  postgres:

--- a/aggregation/infra/postgres/servers.json
+++ b/aggregation/infra/postgres/servers.json
@@ -1,0 +1,13 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "aggregation",
+      "Group": "Servers",
+      "Port": 5432,
+      "Username": "postgres",
+      "Host": "aggregation-postgres",
+      "SSLMode": "prefer",
+      "MaintenanceDB": "postgres"
+    }
+  }
+}

--- a/aggregation/run-infra-deps.sh
+++ b/aggregation/run-infra-deps.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker-compose -f docker-compose.infra.yml up aggregation-postgres aggregation-postgres-admin


### PR DESCRIPTION
To demo the idea of running infra deps locally via docker compose, this PR adds that functionality for PostgreSQL to `aggregation` (even though the code does not use the dependency).