### PR TITLE
formalize inter-BC compile-time dep; deploy on release branch

### DIFF
--- a/.github/workflows/aggregation.yml
+++ b/.github/workflows/aggregation.yml
@@ -72,6 +72,7 @@ jobs:
           --project ddd-vienna-sample
         working-directory: aggregation/artifacts/aggregation-application
         if: github.ref == 'refs/heads/main'
+
   terraform:
     name: Terraform
     needs: build
@@ -113,4 +114,4 @@ jobs:
 
       - name: Apply
         run: terraform apply -input=false terraform.plan
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/release'

--- a/.github/workflows/forwarding.yml
+++ b/.github/workflows/forwarding.yml
@@ -3,7 +3,10 @@ concurrency: forwarding-${{ github.ref }}
 
 on:
   workflow_dispatch:
-#  push:
+  push:
+    paths:
+      - "aggregation/src/Contracts"
+
 
 jobs:
   build:
@@ -86,6 +89,7 @@ jobs:
           --project ddd-vienna-sample
         working-directory: forwarding/artifacts/webhook-application
         if: github.ref == 'refs/heads/main'
+
   terraform:
     name: Terraform
     needs: build
@@ -128,4 +132,4 @@ jobs:
 
       - name: Apply
         run: terraform apply -input=false terraform.plan
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/release'


### PR DESCRIPTION
This PR

- formalizes the dependency from `Forwarding` to `Aggregation.Contracts`  in GHA (early),
- changes the `terraform` GHA step to deploy only on push to `release` (mid?)