### PR TITLE
[AGGREGATION] Define providerIds & add them to signals

### DIFF
--- a/aggregation/src/Application/Domain/Providers/ProviderA.fs
+++ b/aggregation/src/Application/Domain/Providers/ProviderA.fs
@@ -4,6 +4,8 @@ open System
 open NodaTime
 open FsToolkit.ErrorHandling
 
+let providerId = Guid.Parse("05da02cd-65f6-4688-81a2-19053c9dd0b4") |> ProviderId
+
 let randomValidSignal(clock: IClock) =
     let rnd = Random()
 
@@ -18,3 +20,5 @@ type ProviderA(clock: IClock) =
         member this.GetSignal() = taskResult {
             return randomValidSignal(clock)
         }
+
+        member this.ProviderId = providerId

--- a/aggregation/src/Application/Domain/Providers/ProviderB.fs
+++ b/aggregation/src/Application/Domain/Providers/ProviderB.fs
@@ -4,6 +4,8 @@ open System
 open NodaTime
 open FsToolkit.ErrorHandling
 
+let providerId = Guid.Parse("472cdf1e-d222-4e9a-b7eb-164e67d044ff") |> ProviderId
+
 let randomInvalidSignal(clock: IClock) =
     let rnd = Random()
 
@@ -18,3 +20,5 @@ type ProviderB(clock: IClock) =
         member this.GetSignal() = taskResult {
             return randomInvalidSignal(clock)
         }
+
+        member this.ProviderId = providerId

--- a/aggregation/src/Application/Domain/Providers/Providers.fs
+++ b/aggregation/src/Application/Domain/Providers/Providers.fs
@@ -3,14 +3,21 @@ namespace Application.Domain.Providers
 [<AutoOpen>]
 module Providers =
 
+    open System
     open FsToolkit.ErrorHandling
     open NodaTime
+
+    type ProviderId = ProviderId of Guid
+
+    module ProviderId =
+        let value (ProviderId id) = id
 
     type ProviderSignal = {
         Latitude: decimal
         Longitude: decimal
-        Timestamp: Instant        
+        Timestamp: Instant
     }
 
     type IProvider =
         abstract GetSignal: unit -> TaskResult<ProviderSignal, exn>
+        abstract ProviderId: ProviderId

--- a/aggregation/src/Application/Domain/SignalValidation.fs
+++ b/aggregation/src/Application/Domain/SignalValidation.fs
@@ -3,8 +3,7 @@ module Application.Domain.SignalValidation
 open Aggregation.Contracts.Signals.V1
 open Application.Domain.Providers
 
-let validate (providerSignal: ProviderSignal) : Signal =
-    let validationResult =
+let validate (providerSignal: ProviderSignal) : ValidationResult =
         match providerSignal.Latitude, providerSignal.Longitude with
         | lat, _ when lat < -90m || 90m < lat ->
             "Latitude outside of [-90, 90]"
@@ -13,9 +12,3 @@ let validate (providerSignal: ProviderSignal) : Signal =
             "Longitude outside of [-180, 180]"
             |> Invalid
         | _, _ -> Valid
-    {
-        Latitude = providerSignal.Latitude
-        Longitude = providerSignal.Longitude
-        Timestamp = providerSignal.Timestamp
-        ValidationResult = validationResult 
-    }

--- a/aggregation/src/Application/Routes.fs
+++ b/aggregation/src/Application/Routes.fs
@@ -14,4 +14,4 @@ let routes : HttpFunc -> HttpContext -> HttpFuncResult =
             choose [
                 route "/aggregate-from-providers" >=> AggregateFromProviders.handler
             ]
-        setStatusCode 404 >=> text "Not Found" ]    
+        setStatusCode 404 >=> text "Not Found" ]

--- a/aggregation/src/Contracts/Signals.fs
+++ b/aggregation/src/Contracts/Signals.fs
@@ -3,6 +3,7 @@
 module Signals =
     module V1 =
 
+        open System
         open System.Text.Json
         open System.Text.Json.Serialization
         open NodaTime
@@ -17,6 +18,7 @@ module Signals =
             Longitude: decimal
             Timestamp: Instant
             ValidationResult: ValidationResult
+            ProviderId: Guid
         }
         
         let setupJsonOptions() =


### PR DESCRIPTION
This PR adds `ProviderId`s (GUIDs) to signals aggregated in `aggregation` so that other BCs can identify the provider from which the signal was aggregated.